### PR TITLE
feat: make stacktrace level configurable and document behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Text and JSON output formats.
 - Multiple output destinations: stdout, stderr, file paths, multi-target.
 - Automatic timestamp, source file and line number.
-- Stacktrace collection for error-level messages.
+- Stacktrace support with configurable stacktrace level.
 - Test suite for core functionality.
 - Idiomatic Go examples (testable examples).
 - Makefile, GitHub Actions CI workflow, README, LICENSE, lint configuration.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
     - [type Opts](#type-opts)
     - [Main API](#main-api)
   - [Log levels](#log-levels)
+  - [Stacktraces](#stacktraces)
+    - [Overriding stacktrace level](#overriding-stacktrace-level)
   - [Output formats](#output-formats)
   - [Output destinations](#output-destinations)
   - [Examples](#examples)
@@ -37,7 +39,7 @@ and fine-grained log-level control.
 - Multiple output targets: **stdout**, **stderr**, **files**
 - Log levels: `Trace`, `Debug`, `Info`, `Warn`, `Error`
 - Automatic timestamp, source file, and line number
-- Stacktrace for errors
+- Automatic stacktraces based on log level
 
 ---
 
@@ -73,7 +75,7 @@ func main() {
 	}
 	defer log.Close()
 
-	logger := log.Logger().With(tlog.String("component", "demo"))
+	logger := log.Logger().With(slog.String("component", "demo"))
 	logger.Info("service started", "port", 8080)
 	logger.Error("failed to connect", "err", "timeout")
 }
@@ -119,6 +121,40 @@ type Opts struct {
 | `Info`  | Normal operational messages                 |
 | `Warn`  | Non-fatal warnings                          |
 | `Error` | Errors and exceptions (includes stacktrace) |
+
+---
+
+## Stacktraces
+
+`go-tlog` can automatically attach stacktraces to log records.
+
+By default, the stacktrace threshold is the same as the configured log level.
+This means that stacktraces are added starting from the current log level
+and for all higher-severity messages.
+
+The default behavior is:
+
+| Log level | Stacktrace is added for          |
+|-----------|----------------------------------|
+| `Trace`   | `DEBUG`, `INFO`, `WARN`, `ERROR` |
+| `Debug`   | `DEBUG`, `INFO`, `WARN`, `ERROR` |
+| `Info`    | `INFO`, `WARN`, `ERROR`          |
+| `Warn`    | `WARN`, `ERROR`                  |
+| `Error`   | `ERROR`                          |
+
+You can override this behavior using `StacktraceLevel` to control
+the stacktrace threshold independently of the log level.
+
+### Overriding stacktrace level
+
+```go
+log, err := tlog.New(tlog.Opts{
+    Level:           tlog.LevelInfo,
+    StacktraceLevel: tlog.LevelError,
+    Format:          tlog.FormatText,
+    Path:            "stdout",
+})
+```
 
 ---
 

--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,10 @@ type Opts struct {
 	// Use "stdout" and "stderr" for os streams and file paths for files.
 	// Default is "stderr".
 	Path string
+	// StacktraceLevel overrides the default stacktrace threshold.
+	// If set, stacktraces will be attached starting from this level,
+	// regardless of the main log Level.
+	StacktraceLevel Level
 }
 
 // New creates a new Logger with the given options.
@@ -39,22 +43,37 @@ func New(opts Opts) (*Logger, error) {
 
 	switch opts.Level {
 	case LevelTrace:
-		traceLevel = slog.LevelDebug
-		logLevel = slog.LevelDebug
+		fallthrough
 	case LevelDebug:
-		traceLevel = slog.LevelError
+		traceLevel = slog.LevelDebug
 		logLevel = slog.LevelDebug
 	case LevelDefault:
 		fallthrough
 	case LevelInfo:
-		traceLevel = slog.LevelError
+		traceLevel = slog.LevelInfo
 		logLevel = slog.LevelInfo
 	case LevelWarn:
-		traceLevel = slog.LevelError
+		traceLevel = slog.LevelWarn
 		logLevel = slog.LevelWarn
 	case LevelError:
 		traceLevel = slog.LevelError
 		logLevel = slog.LevelError
+	}
+
+	// Override stacktrace level if explicitly configured.
+	if opts.StacktraceLevel != 0 {
+		switch opts.StacktraceLevel {
+		case LevelTrace, LevelDebug:
+			traceLevel = slog.LevelDebug
+		case LevelInfo:
+			traceLevel = slog.LevelInfo
+		case LevelWarn:
+			traceLevel = slog.LevelWarn
+		case LevelError:
+			traceLevel = slog.LevelError
+		default:
+			traceLevel = slog.LevelDebug
+		}
 	}
 
 	if opts.Path == "" {

--- a/logger_test.go
+++ b/logger_test.go
@@ -24,9 +24,10 @@ func Test_Logger(t *testing.T) {
 		{
 			name: "InfoMessage_DebugTextLogger",
 			opts: tlog.Opts{
-				Level:  tlog.LevelDebug,
-				Format: tlog.FormatText,
-				Path:   "InfoMessage_DebugPlainLogger.log",
+				Level:           tlog.LevelDebug,
+				StacktraceLevel: tlog.LevelError,
+				Format:          tlog.FormatText,
+				Path:            "InfoMessage_DebugPlainLogger.log",
 			},
 			log: func(l *slog.Logger) {
 				l.Info("my info message")
@@ -36,6 +37,23 @@ func Test_Logger(t *testing.T) {
 			assert: func(require *require.Assertions, logs string) {
 				require.Contains(logs, "my info message")
 				require.NotContains(logs, "stacktrace=")
+			},
+		},
+		{
+			name: "WarnMessage_InfoTextLogger_WithWarnStacktraceLevel",
+			opts: tlog.Opts{
+				Level:           tlog.LevelInfo,
+				StacktraceLevel: tlog.LevelWarn,
+				Format:          tlog.FormatText,
+				Path:            "WarnMessage_InfoTextLogger_WithWarnStacktraceLevel.log",
+			},
+			log: func(l *slog.Logger) {
+				l.Warn("my warn message")
+			},
+			assert: func(require *require.Assertions, logs string) {
+				require.Contains(logs, "my warn message")
+				require.Contains(logs, "stacktrace=")
+				require.Contains(logs, "tlog_test.Test_Logger")
 			},
 		},
 		{
@@ -104,6 +122,22 @@ func Test_Logger(t *testing.T) {
 			},
 		},
 		{
+			name: "InfoMessage_TraceTextLogger_WithErrorStacktraceLevel",
+			opts: tlog.Opts{
+				Level:           tlog.LevelTrace,
+				StacktraceLevel: tlog.LevelError,
+				Format:          tlog.FormatText,
+				Path:            "InfoMessage_TraceTextLogger_WithErrorStacktraceLevel.log",
+			},
+			log: func(l *slog.Logger) {
+				l.Info("my info message")
+			},
+			assert: func(require *require.Assertions, logs string) {
+				require.Contains(logs, "my info message")
+				require.NotContains(logs, "stacktrace=")
+			},
+		},
+		{
 			name: "InfoMessage_DefaultLogger",
 			opts: tlog.Opts{
 				// Level and Format will be defaulted by New.
@@ -119,9 +153,10 @@ func Test_Logger(t *testing.T) {
 		{
 			name: "InfoMessage_DebugJSONLogger",
 			opts: tlog.Opts{
-				Level:  tlog.LevelDebug,
-				Format: tlog.FormatJSON,
-				Path:   "InfoMessage_DebugPlainLogger.json",
+				Level:           tlog.LevelDebug,
+				StacktraceLevel: tlog.LevelError,
+				Format:          tlog.FormatJSON,
+				Path:            "InfoMessage_DebugPlainLogger.json",
 			},
 			log: func(l *slog.Logger) {
 				l.Info("my info message")


### PR DESCRIPTION
Stacktrace behavior update:

- Stacktrace threshold now defaults to the configured log level
- Added StacktraceLevel option to override stacktrace threshold explicitly
- Updated README to document stacktrace semantics and configuration