### PR TITLE
handler: add separate json/text handlers

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package tlog_test
 
 import (
 	"log/slog"
+	"os"
 
 	"github.com/tarantool/go-tlog"
 )
@@ -55,4 +56,28 @@ func ExampleNew_multi() {
 
 	logger := log.Logger().With(slog.String("component", "example_multi"))
 	logger.Info("message written to stdout and file")
+}
+
+// ExampleNewJSONHandler shows how to create a JSON handler
+// that writes to any io.Writer.
+func ExampleNewJSONHandler() {
+	handler := tlog.NewJSONHandler(os.Stdout, &tlog.HandlerOptions{
+		Level:           tlog.LevelInfo,
+		StacktraceLevel: tlog.LevelError,
+	})
+	logger := slog.New(handler)
+
+	logger.Info("service started")
+}
+
+// ExampleNewTextHandler shows how to create a text handler
+// that writes to any io.Writer.
+func ExampleNewTextHandler() {
+	handler := tlog.NewTextHandler(os.Stdout, &tlog.HandlerOptions{
+		Level:           tlog.LevelInfo,
+		StacktraceLevel: tlog.LevelError,
+	})
+	logger := slog.New(handler)
+
+	logger.Info("service started")
 }

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,99 @@
+package tlog
+
+import (
+	"io"
+	"log/slog"
+
+	slogcustom "github.com/tarantool/go-tlog/internal/slog"
+)
+
+// HandlerOptions are options for NewJSONHandler and NewTextHandler.
+type HandlerOptions struct {
+	// Level sets minimum level for the handler.
+	Level Level
+	// StacktraceLevel overrides the default stacktrace threshold.
+	// If set, stacktraces will be attached starting from this level,
+	// regardless of the main log Level.
+	StacktraceLevel Level
+	// ReplaceAttr is called to rewrite each non-group Attr before
+	// it is logged. See slog.HandlerOptions for details.
+	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
+	// AddSource causes the handler to compute the source code position
+	// of the log statement and add a SourceKey attribute to the output.
+	AddSource bool
+}
+
+func (o *HandlerOptions) slogHandlerOptions() slog.HandlerOptions {
+	opts := slog.HandlerOptions{
+		AddSource: o.AddSource,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			a = replaceAttr(groups, a)
+			if o.ReplaceAttr != nil {
+				a = o.ReplaceAttr(groups, a)
+			}
+			return a
+		},
+	}
+
+	switch o.Level {
+	case LevelTrace, LevelDebug:
+		opts.Level = slog.LevelDebug
+	case LevelDefault, LevelInfo:
+		opts.Level = slog.LevelInfo
+	case LevelWarn:
+		opts.Level = slog.LevelWarn
+	case LevelError:
+		opts.Level = slog.LevelError
+	}
+
+	return opts
+}
+
+func (o *HandlerOptions) slogTraceLevel() slog.Level {
+	level := o.Level
+	if o.StacktraceLevel != 0 {
+		level = o.StacktraceLevel
+	}
+
+	switch level {
+	case LevelTrace, LevelDebug:
+		return slog.LevelDebug
+	case LevelDefault, LevelInfo:
+		return slog.LevelInfo
+	case LevelWarn:
+		return slog.LevelWarn
+	case LevelError:
+		return slog.LevelError
+	default:
+		return slog.LevelDebug
+	}
+}
+
+// NewJSONHandler creates a slog.Handler that writes JSON output to w.
+// If opts is nil, default options are used.
+func NewJSONHandler(w io.Writer, opts *HandlerOptions) slog.Handler {
+	if opts == nil {
+		opts = &HandlerOptions{}
+	}
+
+	handlerOpts := opts.slogHandlerOptions()
+	base := slog.NewJSONHandler(w, &handlerOpts)
+
+	return newStacktraceHandler(base, opts.slogTraceLevel())
+}
+
+// NewTextHandler creates a slog.Handler that writes text output to w.
+// If opts is nil, default options are used.
+func NewTextHandler(w io.Writer, opts *HandlerOptions) slog.Handler {
+	if opts == nil {
+		opts = &HandlerOptions{}
+	}
+
+	handlerOpts := opts.slogHandlerOptions()
+	base := slogcustom.NewTextHandler(w, &slogcustom.HandlerOptions{
+		HandlerOptions:  handlerOpts,
+		OmitBuiltinKeys: true,
+	})
+
+	return newStacktraceHandler(base, opts.slogTraceLevel())
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,166 @@
+package tlog_test
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-tlog"
+)
+
+func Test_NewJSONHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes JSON to io.Writer", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewJSONHandler(&buf, &tlog.HandlerOptions{
+			Level:           tlog.LevelDebug,
+			StacktraceLevel: tlog.LevelError,
+		})
+		logger := slog.New(handler)
+
+		logger.Info("hello json")
+
+		r := require.New(t)
+		r.Contains(buf.String(), `"msg":"hello json"`)
+		r.Contains(buf.String(), `"level":"INFO"`)
+		r.NotContains(buf.String(), `"stacktrace"`)
+	})
+
+	t.Run("includes stacktrace at error", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewJSONHandler(&buf, &tlog.HandlerOptions{
+			Level: tlog.LevelDebug,
+		})
+		logger := slog.New(handler)
+
+		logger.Error("fail")
+
+		r := require.New(t)
+		r.Contains(buf.String(), `"msg":"fail"`)
+		r.Contains(buf.String(), `"stacktrace"`)
+	})
+
+	t.Run("nil opts uses defaults", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewJSONHandler(&buf, nil)
+		logger := slog.New(handler)
+
+		logger.Info("default opts")
+
+		r := require.New(t)
+		r.Contains(buf.String(), `"msg":"default opts"`)
+	})
+
+	t.Run("respects level filtering", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewJSONHandler(&buf, &tlog.HandlerOptions{
+			Level: tlog.LevelError,
+		})
+		logger := slog.New(handler)
+
+		logger.Info("should be dropped")
+
+		r := require.New(t)
+		r.Empty(buf.String())
+	})
+
+	t.Run("ReplaceAttr is applied", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewJSONHandler(&buf, &tlog.HandlerOptions{
+			Level:           tlog.LevelInfo,
+			StacktraceLevel: tlog.LevelError,
+			ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.MessageKey {
+					a.Value = slog.StringValue("replaced")
+				}
+				return a
+			},
+		})
+		logger := slog.New(handler)
+
+		logger.Info("original")
+
+		r := require.New(t)
+		r.Contains(buf.String(), `"msg":"replaced"`)
+		r.NotContains(buf.String(), `"msg":"original"`)
+	})
+}
+
+func Test_NewTextHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes text to io.Writer", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewTextHandler(&buf, &tlog.HandlerOptions{
+			Level:           tlog.LevelDebug,
+			StacktraceLevel: tlog.LevelError,
+		})
+		logger := slog.New(handler)
+
+		logger.Info("hello text")
+
+		r := require.New(t)
+		r.Contains(buf.String(), "hello text")
+		r.Contains(buf.String(), "INFO")
+		r.NotContains(buf.String(), "stacktrace=")
+	})
+
+	t.Run("includes stacktrace at error", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewTextHandler(&buf, &tlog.HandlerOptions{
+			Level: tlog.LevelDebug,
+		})
+		logger := slog.New(handler)
+
+		logger.Error("fail text")
+
+		r := require.New(t)
+		r.Contains(buf.String(), "fail text")
+		r.Contains(buf.String(), "stacktrace=")
+	})
+
+	t.Run("nil opts uses defaults", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewTextHandler(&buf, nil)
+		logger := slog.New(handler)
+
+		logger.Info("default opts")
+
+		r := require.New(t)
+		r.Contains(buf.String(), "default opts")
+	})
+
+	t.Run("respects level filtering", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := tlog.NewTextHandler(&buf, &tlog.HandlerOptions{
+			Level: tlog.LevelError,
+		})
+		logger := slog.New(handler)
+
+		logger.Info("should be dropped")
+
+		r := require.New(t)
+		r.Empty(buf.String())
+	})
+}


### PR DESCRIPTION
Add `NewJSONHandler` and `NewTextHandler` constructors that accept any io.Writer and return a standard slog.Handler. This makes the library conformant with the slog handler guide and allows usage with `slog.New(handler)` directly.

Closes #3.