### PR TITLE
ci: migrate golangci-lint to v2.10.1

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,10 +1,13 @@
 name: testing
 
+env:
+  GOLANGCI_LINT_VERSION: v2.11.4
+
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ '**' ]
+    branches: ["**"]
   workflow_dispatch:
 
 jobs:
@@ -18,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: "1.24.x"
           check-latest: true
 
       - name: Download deps
@@ -37,15 +40,18 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         continue-on-error: true
         with:
           # The first run is for GitHub Actions error format.
           args: --config=.golangci.yaml
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
           # The second run is for human-readable error format with a file name
           # and a line number.
-          args: --out-${NO_FUTURE}format colored-line-number --config=.golangci.yaml
+          args: --output.text.path stdout --config=.golangci.yaml
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,10 @@
+version: "2"
+
 run:
   timeout: 5m
   modules-download-mode: readonly
 
 issues:
-  exclude-use-default: false
   max-same-issues: 0
   max-issues-per-linter: 0
 
@@ -13,36 +14,34 @@ linters:
     - staticcheck
     - revive
     - errcheck
-    - gosimple
     - ineffassign
     - unused
-    - typecheck
-    - gofmt
-    - goimports
     - misspell
     - gocritic
-
-linters-settings:
-  revive:
-    severity: warning
+  settings:
+    revive:
+      severity: warning
+      rules:
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: indent-error-flow
+        - name: exported
+        - name: blank-imports
+        - name: var-declaration
+        - name: if-return
+    misspell:
+      locale: US
+  exclusions:
     rules:
-      - name: unused-parameter
-      - name: unreachable-code
-      - name: indent-error-flow
-      - name: exported
-      - name: blank-imports
-      - name: var-declaration
-      - name: if-return
+      - path: ^_examples/
+        linters: [revive, staticcheck, govet, gocritic]
+      - path: \.pb\.go$|_gen\.go$
+        linters: [all]
 
-  misspell:
-    locale: US
-
-  goimports:
-    local-prefixes: github.com/tarantool/go-tlog
-
-# Skip linters on example files and any generated code
-exclude-rules:
-  - path: ^_examples/
-    linters: [revive, staticcheck, govet, gocritic]
-  - path: \.pb\.go$|_gen\.go$
-    linters: [all]
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes: [github.com/tarantool/go-tlog]


### PR DESCRIPTION
- Update .golangci.yaml to v2 format.
- Update golangci-lint action to v9.

Closes #5.