### PR TITLE
outputs: support reopening files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Text and JSON handlers compatible with slog.
+- Support for reopening log files.
 
 ### Changed
+- Logger outputs close is thread-safe now.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Text and JSON handlers compatible with slog.
+
+### Changed
+
+### Fixed
+
+
+## [v1.0.0] - 2026-01-13
+
+### Added
 
 - Core structured logging library for Go.
 - Support for log levels: Trace, Debug, Info, Warn, Error.
@@ -18,7 +28,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Test suite for core functionality.
 - Idiomatic Go examples (testable examples).
 - Makefile, GitHub Actions CI workflow, README, LICENSE, lint configuration.
-
-### Changed
-
-### Fixed

--- a/example_test.go
+++ b/example_test.go
@@ -1,8 +1,12 @@
 package tlog_test
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/tarantool/go-tlog"
 )
@@ -80,4 +84,65 @@ func ExampleNewTextHandler() {
 	logger := slog.New(handler)
 
 	logger.Info("service started")
+}
+
+// ExampleLogger_Reopen shows how to reopen log file outputs.
+// It is useful for integrating with logrotate: after an external
+// tool moves the log file aside, call Reopen so that subsequent
+// log entries are written to a freshly created file.
+func ExampleLogger_Reopen() {
+	path := "/tmp/tlog_example_reopen.log"
+
+	log, err := tlog.New(tlog.Opts{
+		Level:  tlog.LevelInfo,
+		Format: tlog.FormatText,
+		Path:   path,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = log.Close() }()
+
+	logger := log.Logger().With(slog.String("component", "example_reopen"))
+	logger.Info("message before rotation")
+
+	// Simulate logrotate: move the current file aside.
+	if err := os.Rename(path, path+".1"); err != nil {
+		panic(err)
+	}
+
+	// Reopen outputs so new entries go to a newly created file.
+	if err := log.Reopen(); err != nil {
+		panic(err)
+	}
+
+	logger.Info("message after rotation")
+}
+
+// ExampleLogger_ReopenOnSignal shows how to reopen log file outputs
+// automatically when a signal is received. It is intended to be run in
+// a separate goroutine, e.g. to reopen logs on SIGHUP sent by logrotate.
+func ExampleLogger_ReopenOnSignal() {
+	log, err := tlog.New(tlog.Opts{
+		Level:  tlog.LevelInfo,
+		Format: tlog.FormatText,
+		Path:   "/tmp/tlog_example_reopen_on_signal.log",
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = log.Close() }()
+
+	// Stop reopening on Ctrl+C / termination.
+	ctx, stop := signal.NotifyContext(
+		context.Background(), syscall.SIGINT, syscall.SIGTERM,
+	)
+	defer stop()
+
+	// Reopen log files each time SIGHUP is received.
+	go log.ReopenOnSignal(ctx, func(err error) {
+		fmt.Fprintf(os.Stderr, "log reopen failed: %v\n", err)
+	}, syscall.SIGHUP)
+
+	log.Logger().Info("service started")
 }

--- a/internal/outputs/outputs.go
+++ b/internal/outputs/outputs.go
@@ -7,10 +7,13 @@ import (
 	"io/fs"
 	"os"
 	"strings"
+	"sync"
 )
 
 // Outputs is io.WriteCloser for multiple output paths.
 type Outputs struct {
+	mu    sync.RWMutex
+	paths []string
 	files []*os.File
 	w     io.Writer
 }
@@ -22,27 +25,37 @@ func New(paths string) (*Outputs, error) {
 		return nil, errors.New("empty paths")
 	}
 
-	slice := splitPaths(paths)
+	pathsSlice := splitPaths(paths)
 
-	files := make([]*os.File, 0, len(slice))
-	writers := make([]io.Writer, 0, len(slice))
+	files, w, err := openFiles(pathsSlice)
+	if err != nil {
+		return nil, err
+	}
 
-	for _, path := range slice {
+	return &Outputs{
+		paths: pathsSlice,
+		files: files,
+		w:     w,
+	}, nil
+}
+
+func openFiles(paths []string) ([]*os.File, io.Writer, error) {
+	files := make([]*os.File, 0, len(paths))
+	writers := make([]io.Writer, 0, len(paths))
+
+	for _, path := range paths {
 		file, err := openFile(path)
 		if err != nil {
 			_ = multiClose(files)
 
-			return nil, fmt.Errorf("failed to open path %q: %w", path, err)
+			return nil, nil, fmt.Errorf("failed to open path %q: %w", path, err)
 		}
 
 		files = append(files, file)
 		writers = append(writers, file)
 	}
 
-	return &Outputs{
-		files: files,
-		w:     io.MultiWriter(writers...),
-	}, nil
+	return files, io.MultiWriter(writers...), nil
 }
 
 func splitPaths(paths string) []string {
@@ -95,10 +108,38 @@ func multiClose(files []*os.File) error {
 // Write writes p to all configured output destinations.
 // It implements io.Writer and is used by slog handlers.
 func (o *Outputs) Write(p []byte) (int, error) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
 	return o.w.Write(p)
+}
+
+// Reopen closes current file outputs and opens them once again.
+// Can be used for logrotate.
+func (o *Outputs) Reopen() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	files, w, err := openFiles(o.paths)
+	if err != nil {
+		return fmt.Errorf("failed to reopen outputs: %w", err)
+	}
+
+	oldFiles := o.files
+	o.files = files
+	o.w = w
+
+	if err := multiClose(oldFiles); err != nil {
+		return fmt.Errorf("failed to close old outputs (reopen succeeded): %w", err)
+	}
+
+	return nil
 }
 
 // Close closes all file outputs except stdout and stderr.
 func (o *Outputs) Close() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	return multiClose(o.files)
 }

--- a/internal/outputs/outputs_test.go
+++ b/internal/outputs/outputs_test.go
@@ -84,10 +84,7 @@ func Test_Outputs_Std(t *testing.T) {
 func Test_Outputs_File(t *testing.T) {
 	require := require.New(t)
 
-	filename := filepath.Join(os.TempDir(), "Test_Outputs_File.log")
-	defer func(name string) {
-		_ = os.Remove(name)
-	}(filename)
+	filename := filepath.Join(t.TempDir(), "Test_Outputs_File.log")
 
 	outputs, err := outputs.New(filename)
 	require.NoError(err)
@@ -104,10 +101,7 @@ func Test_Outputs_Multiple(t *testing.T) {
 	require := require.New(t)
 
 	// Prepare file 1.
-	filename1 := filepath.Join(os.TempDir(), "Test_Outputs_Multiple1.log")
-	defer func(name string) {
-		_ = os.Remove(name)
-	}(filename1)
+	filename1 := filepath.Join(t.TempDir(), "Test_Outputs_Multiple1.log")
 
 	// Prepare stdout.
 	r, w, _ := os.Pipe()
@@ -120,10 +114,7 @@ func Test_Outputs_Multiple(t *testing.T) {
 	}()
 
 	// Prepare file 2.
-	filename2 := filepath.Join(os.TempDir(), "Test_Outputs_Multiple2.log")
-	defer func(name string) {
-		_ = os.Remove(name)
-	}(filename2)
+	filename2 := filepath.Join(t.TempDir(), "Test_Outputs_Multiple2.log")
 
 	outputs, err := outputs.New(filename1 + ",stdout," + filename2)
 	require.NoError(err)

--- a/internal/outputs/outputs_test.go
+++ b/internal/outputs/outputs_test.go
@@ -139,3 +139,36 @@ func Test_Outputs_Multiple(t *testing.T) {
 	require.NoError(err)
 	require.Contains(string(file2Out), "log_message")
 }
+
+func Test_Outputs_Rotate(t *testing.T) {
+	require := require.New(t)
+
+	filename := filepath.Join(t.TempDir(), "Test_Outputs_File.log")
+
+	outputs, err := outputs.New(filename)
+	require.NoError(err)
+
+	_, err = outputs.Write([]byte("log_message1"))
+	require.NoError(err)
+
+	rotated := filename + ".1"
+
+	err = os.Rename(filename, rotated)
+	require.NoError(err)
+
+	err = outputs.Reopen()
+	require.NoError(err)
+
+	_, err = outputs.Write([]byte("log_message2"))
+	require.NoError(err)
+
+	outOld, err := os.ReadFile(rotated)
+	require.NoError(err)
+	require.Contains(string(outOld), "log_message1")
+	require.NotContains(string(outOld), "log_message2")
+
+	out, err := os.ReadFile(filename)
+	require.NoError(err)
+	require.NotContains(string(out), "log_message1")
+	require.Contains(string(out), "log_message2")
+}

--- a/logger.go
+++ b/logger.go
@@ -1,8 +1,11 @@
 package tlog
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"os/signal"
 	"time"
 
 	"github.com/tarantool/go-tlog/internal/outputs"
@@ -10,7 +13,7 @@ import (
 )
 
 // Logger contains slog.Logger for several outputs
-// and method to close these outputs.
+// and methods to reopen or close these outputs.
 type Logger struct {
 	outputs *outputs.Outputs
 	logger  *slog.Logger
@@ -136,6 +139,41 @@ func replaceTime(_ []string, a slog.Attr) slog.Attr {
 // It can be used directly to log messages with additional attributes.
 func (l *Logger) Logger() *slog.Logger {
 	return l.logger
+}
+
+// Reopen closes current file outputs and opens them once again.
+// Can be used for logrotate.
+func (l *Logger) Reopen() error {
+	return l.outputs.Reopen()
+}
+
+// ReopenOnSignal calls Reopen each time one of sigs arrives and returns when
+// ctx is done. It is blocking, intended to run in a goroutine:
+//
+//	go log.ReopenOnSignal(ctx, func(err error) {
+//	        fmt.Fprintf(os.Stderr, "log reopen failed: %v\n", err)
+//	}, syscall.SIGHUP)
+//
+// onErr must not write through this Logger.
+func (l *Logger) ReopenOnSignal(ctx context.Context, onErr func(error), sigs ...os.Signal) {
+	if len(sigs) == 0 {
+		return
+	}
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sigs...)
+	defer signal.Stop(ch)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+			if err := l.Reopen(); err != nil && onErr != nil {
+				onErr(err)
+			}
+		}
+	}
 }
 
 // Close flushes all pending log entries and closes all opened outputs.

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,10 +1,16 @@
 package tlog_test
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -239,4 +245,157 @@ func Test_Logger(t *testing.T) {
 			tc.assert(r, string(logs))
 		})
 	}
+}
+
+func Test_LoggerReopen(t *testing.T) {
+	t.Parallel()
+
+	r := require.New(t)
+
+	dir := t.TempDir()
+
+	filename := filepath.Join(dir, "Test_LoggerReopen.log")
+
+	l, err := tlog.New(tlog.Opts{Path: filename})
+	r.NoError(err)
+
+	defer func() {
+		_ = l.Close()
+	}()
+
+	l.Logger().Info("log_message1")
+
+	rotated := filename + ".1"
+
+	err = os.Rename(filename, rotated)
+	r.NoError(err)
+
+	err = l.Reopen()
+	r.NoError(err)
+
+	l.Logger().Info("log_message2")
+
+	outOld, err := os.ReadFile(rotated)
+	r.NoError(err)
+	r.Contains(string(outOld), "log_message1")
+	r.NotContains(string(outOld), "log_message2")
+
+	out, err := os.ReadFile(filename)
+	r.NoError(err)
+	r.NotContains(string(out), "log_message1")
+	r.Contains(string(out), "log_message2")
+}
+
+func Test_LoggerReopenOnSignal(t *testing.T) {
+	// Do not run in parallel, sends signals to self process.
+
+	r := require.New(t)
+
+	dir := t.TempDir()
+
+	filename := filepath.Join(dir, "Test_LoggerReopenOnSignal.log")
+
+	l, err := tlog.New(tlog.Opts{Path: filename})
+	r.NoError(err)
+
+	defer func() {
+		_ = l.Close()
+	}()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go l.ReopenOnSignal(ctx, func(err error) {
+		fmt.Fprintf(os.Stderr, "log reopen failed: %v\n", err)
+	}, syscall.SIGUSR1)
+
+	oldMessage := "log_message"
+	l.Logger().Info(oldMessage)
+
+	rotated := filename + ".1"
+
+	err = os.Rename(filename, rotated)
+	r.NoError(err)
+
+	// We cannot guarantee that signal has been already processed, so let's
+	// retry. The signal may also be lost if the handler goroutine has not
+	// registered with signal.Notify yet, so we re-send it on each iteration
+	// until the reopen takes effect.
+	var newMessage string
+
+	for i := range 10 {
+		err = syscall.Kill(os.Getpid(), syscall.SIGUSR1)
+		r.NoError(err)
+
+		newMessage = fmt.Sprintf("log_newmessage%d", i)
+
+		l.Logger().Info(newMessage)
+
+		out, err := os.ReadFile(rotated)
+		r.NoError(err)
+
+		if !strings.Contains(string(out), newMessage) {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	cancel()
+
+	outOld, err := os.ReadFile(rotated)
+	r.NoError(err)
+	r.Contains(string(outOld), oldMessage)
+	r.NotContains(string(outOld), newMessage)
+
+	out, err := os.ReadFile(filename)
+	r.NoError(err)
+	r.NotContains(string(out), oldMessage)
+	r.Contains(string(out), newMessage)
+}
+
+func Test_LoggerConcurrency(t *testing.T) {
+	t.Parallel()
+
+	r := require.New(t)
+
+	dir := t.TempDir()
+
+	filename := filepath.Join(dir, "Test_LoggerConcurrency.log")
+
+	l, err := tlog.New(tlog.Opts{Path: filename})
+	r.NoError(err)
+
+	defer func() {
+		_ = l.Close()
+	}()
+
+	const goroutines = 100
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(3)
+
+		// Concurrent Logger().Info() calls.
+		go func(n int) {
+			defer wg.Done()
+
+			l.Logger().Info("concurrent info message", slog.Int("n", n))
+		}(i)
+
+		// Concurrent Reopen() calls.
+		go func() {
+			defer wg.Done()
+
+			_ = l.Reopen()
+		}()
+
+		// Concurrent Close() calls.
+		go func() {
+			defer wg.Done()
+
+			_ = l.Close()
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
This patch adds a new handle to a Logger object for reopening configured files. API can be used for application logrotate. This is a backport of a patch from TCF logger, who was the origin of tlog library.