### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,36 @@ and this project adheres to
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.1.0] - 2026-08-04
+
+This release adds standard `slog.Handler` constructors — `NewTextHandler` and
+`NewJSONHandler` over any `io.Writer` — so an application can build its own
+`slog.Logger` with the go-tlog format, and support for reopening file outputs
+so a logger can survive logrotate. It also fixes lost stacktraces on derived
+loggers and a panic in the text format.
+
+### Added
+
 - `NewTextHandler` and `NewJSONHandler` construct a standard `slog.Handler`
   over any `io.Writer`, so an application can build its own `slog.Logger` with
-  the go-tlog format and stacktrace behavior (gh-3).
+  the go-tlog format and stacktrace behavior (#3).
 - `Logger.Reopen` and `Logger.ReopenOnSignal` reopen file outputs, so a logger
-  can survive logrotate.
+  can survive logrotate (#11).
 
 ### Changed
 
-- Logger outputs are safe to close concurrently with writes.
+- Logger outputs are safe to close concurrently with writes (#11).
 
 ### Fixed
 
 - Fixed loggers derived with `Logger.With` or `Logger.WithGroup` silently
-  losing their stacktraces.
+  losing their stacktraces (#12).
 - Fixed a panic in the text format when a `ReplaceAttr` function dropped an
-  attribute by returning the zero `slog.Attr`.
+  attribute by returning the zero `slog.Attr` (#12).
 
 ## [1.0.0] - 2026-01-13
 
@@ -40,7 +54,8 @@ and this project adheres to
 - Timestamp, source file and line number attached to every record.
 - Stacktraces attached automatically from the log level upwards, with
   `StacktraceLevel` to set that threshold independently of the log level
-  (gh-2).
+  (#2).
 
-[Unreleased]: https://github.com/tarantool/go-tlog/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/tarantool/go-tlog/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/tarantool/go-tlog/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/tarantool/go-tlog/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Describe fixes in the past tense and put the issue reference at the end:
 ```markdown
 ### Fixed
 
-- Fixed a panic when Path pointed at an unwritable directory (gh-42).
+- Fixed a panic when Path pointed at an unwritable directory (#42).
 ```
 
 ## License


### PR DESCRIPTION
This release adds standard `slog.Handler` constructors — `NewTextHandler` and `NewJSONHandler` over any `io.Writer` — so an application can build its own `slog.Logger` with the go-tlog format, and support for reopening file outputs so a logger can survive logrotate. It also fixes lost stacktraces on derived loggers and a panic in the text format.

### Added

- `NewTextHandler` and `NewJSONHandler` construct a standard `slog.Handler` over any `io.Writer`, so an application can build its own `slog.Logger` with the go-tlog format and stacktrace behavior (gh-3).
- `Logger.Reopen` and `Logger.ReopenOnSignal` reopen file outputs, so a logger can survive logrotate (gh-11).

### Changed

- Logger outputs are safe to close concurrently with writes (gh-11).

### Fixed

- Fixed loggers derived with `Logger.With` or `Logger.WithGroup` silently losing their stacktraces (gh-12).
- Fixed a panic in the text format when a `ReplaceAttr` function dropped an attribute by returning the zero `slog.Attr` (gh-12).
